### PR TITLE
Changes for integrating with Ewasm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ k_tangler:=".k"
 k_files:=eei-driver.k eei.k
 java_defn:=$(patsubst %,$(java_dir)/%,$(k_files))
 ocaml_defn:=$(patsubst %,$(ocaml_dir)/%,$(k_files))
-haskell_defn:=$(patsubst %,$(haskell_dir)%,$(k_files))
+haskell_defn:=$(patsubst %,$(haskell_dir)/%,$(k_files))
 
 
 defn: defn-ocaml defn-java defn-haskell

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ $(haskell_dir)/%.k: %.md
 
 k_tangler:=".k"
 
-k_files:=eei.k
+k_files:=eei-driver.k eei.k
 java_defn:=$(patsubst %,$(java_dir)/%,$(k_files))
 ocaml_defn:=$(patsubst %,$(ocaml_dir)/%,$(k_files))
 haskell_defn:=$(patsubst %,$(haskell_dir)%,$(k_files))
@@ -96,5 +96,5 @@ build-java: $(BUILD_DIR)/java/driver-kompiled/timestamp
 
 $(BUILD_DIR)/java/driver-kompiled/timestamp: $(java_defn)
 	@echo "== kompile: $@"
-	$(K_BIN)/kompile --debug --main-module EEI --backend java \
-					--syntax-module EEI $< --directory $(BUILD_DIR)/java -I $(BUILD_DIR)/java
+	$(K_BIN)/kompile --debug --main-module EEI-DRIVER --backend java \
+					--syntax-module EEI-DRIVER $< --directory $(BUILD_DIR)/java -I $(BUILD_DIR)/java

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The file [eei] contains the semantics of the EEI.
 Resources
 =========
 
--   [EEI]: On paper specification of the EEI and ewasm.
+-   [EEI]: On paper specification of the EEI and Ewasm.
 -   [EVM Yellowpaper]: Original specification of EVM.
 -   [KEVM]: Specification of EVM in K.
 

--- a/eei-driver.md
+++ b/eei-driver.md
@@ -1,0 +1,21 @@
+EEI Driver
+==========
+
+This definition if for building the EEI semantics independently.
+It only serves to parse an initial program and put it in the `<eeiK>` cell for execution.
+
+```k
+require "eei.k"
+
+module EEI-DRIVER
+  imports EEI
+
+  configuration
+    <k> $PGM:EEIMethods </k>
+    <eei/>
+
+  rule <k> PGM:EEIMethods => . </k>
+       <eeiK> . => PGM </eeiK>
+
+endmodule
+```

--- a/eei-driver.md
+++ b/eei-driver.md
@@ -1,15 +1,19 @@
 EEI Driver
 ==========
 
-This definition if for building the EEI semantics independently.
-It only serves to parse an initial program and put it in the `<eeiK>` cell for execution.
-
 ```k
 require "eei.k"
 
 module EEI-DRIVER
   imports EEI
+```
 
+Since the EEI specification doesn't specify a main cell (with `$PGM` in it), it can be included in other specifications which already have main cells.
+However, to build the EEI semantics independently of other semantics, a main cell is needed.
+This definition is for building the EEI semantics independently.
+It only serves to parse an initial program and put it in the `<eeiK>` cell for execution.
+
+```k
   configuration
     <k> $PGM:EEIMethods </k>
     <eei/>
@@ -17,5 +21,6 @@ module EEI-DRIVER
   rule <k> PGM:EEIMethods => . </k>
        <eeiK> . => PGM </eeiK>
 
+```
 endmodule
 ```

--- a/eei.md
+++ b/eei.md
@@ -233,7 +233,9 @@ EEI Methods
 The EEI signals returns results to an outside caller by wrapping it in a `#result`.
 
 ```k
-    syntax K ::= "#result" "(" Int ")"
+    syntax ResultType ::= Int | List
+    syntax K ::= "#result" "(" ResultType ")"
+ // -----------------------------------------
 ```
 
 The EEI exports several methods which can be invoked by the VM to interact with the client.
@@ -444,7 +446,7 @@ Get the coinbase of the current block.
 ```k
     syntax EEIMethod ::= "EEI.getBlockCoinbase"
  // -------------------------------------------
-    rule <eeiK> EEI.getBlockCoinbase => CBASE ... </eeiK>
+    rule <eeiK> EEI.getBlockCoinbase => #result(CBASE) ... </eeiK>
          <coinbase> CBASE </coinbase>
 ```
 
@@ -457,7 +459,7 @@ Get the difficulty of the current block.
 ```k
     syntax EEIMethod ::= "EEI.getBlockDifficulty"
  // ---------------------------------------------
-    rule <eeiK> EEI.getBlockDifficulty => DIFF ... </eeiK>
+    rule <eeiK> EEI.getBlockDifficulty => #result(DIFF) ... </eeiK>
          <difficulty> DIFF </difficulty>
 ```
 
@@ -470,7 +472,7 @@ Get the gas limit for the current block.
 ```k
     syntax EEIMethod ::= "EEI.getBlockGasLimit"
  // -------------------------------------------
-    rule <eeiK> EEI.getBlockGasLimit => GLIMIT ... </eeiK>
+    rule <eeiK> EEI.getBlockGasLimit => #result(GLIMIT) ... </eeiK>
          <gasLimit> GLIMIT </gasLimit>
 ```
 
@@ -494,11 +496,11 @@ If there are not `N` blocks yet, return `0`.
 ```k
     syntax EEIMethod ::= "EEI.getBlockHash" Int
  // -------------------------------------------
-    rule <eeiK> EEI.getBlockHash N => BLKHASHES[N] ... </eeiK>
+    rule <eeiK> EEI.getBlockHash N => #result(BLKHASHES[N]) ... </eeiK>
          <hashes> BLKHASHES </hashes>
       requires N <Int 256
 
-    rule <eeiK> EEI.getBlockHash N => 0 ... </eeiK>
+    rule <eeiK> EEI.getBlockHash N => #result(0) ... </eeiK>
       requires N >=Int 256
 ```
 
@@ -511,7 +513,7 @@ Get the current block number.
 ```k
     syntax EEIMethod ::= "EEI.getBlockNumber"
  // -----------------------------------------
-    rule <eeiK> EEI.getBlockNumber => BLKNUMBER ... </eeiK>
+    rule <eeiK> EEI.getBlockNumber => #result(BLKNUMBER) ... </eeiK>
          <number> BLKNUMBER </number>
 ```
 
@@ -524,7 +526,7 @@ Get the timestamp of the last block.
 ```k
     syntax EEIMethod ::= "EEI.getBlockTimestamp"
  // --------------------------------------------
-    rule <eeiK> EEI.getBlockTimestamp => TSTAMP ... </eeiK>
+    rule <eeiK> EEI.getBlockTimestamp => #result(TSTAMP) ... </eeiK>
          <timestamp> TSTAMP </timestamp>
 ```
 
@@ -537,7 +539,7 @@ Get the gas price of the current transation.
 ```k
     syntax EEIMethod ::= "EEI.getTxGasPrice"
  // ----------------------------------------
-    rule <eeiK> EEI.getTxGasPrice => GPRICE ... </eeiK>
+    rule <eeiK> EEI.getTxGasPrice => #result(GPRICE) ... </eeiK>
          <gasPrice> GPRICE </gasPrice>
 ```
 
@@ -550,7 +552,7 @@ Get the address which sent this transaction.
 ```k
     syntax EEIMethod ::= "EEI.getTxOrigin"
  // --------------------------------------
-    rule <eeiK> EEI.getTxOrigin => ORG ... </eeiK>
+    rule <eeiK> EEI.getTxOrigin => #result(ORG) ... </eeiK>
          <origin> ORG </origin>
 ```
 
@@ -567,7 +569,7 @@ Return the address of the currently executing account.
 ```k
     syntax EEIMethod ::= "EEI.getAddress"
  // -------------------------------------
-    rule <eeiK> EEI.getAddress => ADDR ... </eeiK>
+    rule <eeiK> EEI.getAddress => #result(ADDR) ... </eeiK>
          <acct> ADDR </acct>
 ```
 
@@ -595,7 +597,7 @@ Returns the calldata associated with this call.
 ```k
     syntax EEIMethod ::= "EEI.getCallData"
  // --------------------------------------
-    rule <eeiK> EEI.getCallData => CDATA ... </eeiK>
+    rule <eeiK> EEI.getCallData => #result(CDATA) ... </eeiK>
          <callData> CDATA </callData>
 ```
 
@@ -608,7 +610,7 @@ Get the value transferred for the current call.
 ```k
     syntax EEIMethod ::= "EEI.getCallValue"
  // ---------------------------------------
-    rule <eeiK> EEI.getCallValue => CVALUE ... </eeiK>
+    rule <eeiK> EEI.getCallValue => #result(CVALUE) ... </eeiK>
          <callValue> CVALUE </callValue>
 ```
 
@@ -621,7 +623,7 @@ Get the gas left available for this execution.
 ```k
     syntax EEIMethod ::= "EEI.getGasLeft"
  // -------------------------------------
-    rule <eeiK> EEI.getGasLeft => GAVAIL ... </eeiK>
+    rule <eeiK> EEI.getGasLeft => #result(GAVAIL) ... </eeiK>
          <gas> GAVAIL </gas>
 ```
 
@@ -636,7 +638,7 @@ Get the return data of the last call.
 ```k
     syntax EEIMethod ::= "EEI.getReturnData"
  // ----------------------------------------
-    rule <eeiK> EEI.getReturnData => RETDATA ... </eeiK>
+    rule <eeiK> EEI.getReturnData => #result(RETDATA) ... </eeiK>
          <returnData> RETDATA </returnData>
 ```
 
@@ -686,7 +688,7 @@ Return the balance of the current account (`ACCT`).
 ```k
     syntax EEIMethod ::= "EEI.getAccountBalance"
  // --------------------------------------------
-    rule <eeiK> EEI.getAccountBalance => BAL ... </eeiK>
+    rule <eeiK> EEI.getAccountBalance => #result(BAL) ... </eeiK>
          <acct> ACCT </acct>
          <account>
            <id> ACCT </id>
@@ -706,7 +708,7 @@ Return the code of the current account (`ACCT`).
 ```k
     syntax EEIMethod ::= "EEI.getAccountCode"
  // -----------------------------------------
-    rule <eeiK> EEI.getAccountCode => ACCTCODE ... </eeiK>
+    rule <eeiK> EEI.getAccountCode => #result(ACCTCODE) ... </eeiK>
          <acct> ACCT </acct>
          <accounts>
            <id> ACCT </id>
@@ -724,7 +726,7 @@ Return the code of the given account `ACCT`.
 ```k
     syntax EEIMethod ::= "EEI.getExternalAccountCode" Int
  // -----------------------------------------------------
-    rule <eeiK> EEI.getExternalAccountCode ACCT => ACCTCODE ... </eeiK>
+    rule <eeiK> EEI.getExternalAccountCode ACCT => #result(ACCTCODE) ... </eeiK>
          <accounts>
            <id> ACCT </id>
            <code> ACCTCODE </code>

--- a/eei.md
+++ b/eei.md
@@ -60,13 +60,13 @@ When stored, it's stored in the `<callStack>` cell as a list.
 
 ```k
         <callState>
-          <callDepth> 0        </callDepth>
-          <acct>      0        </acct>      // I_a
-          <program>   .Code    </program>   // I_b
-          <caller>    0        </caller>    // I_s
-          <callData>  .List    </callData>  // I_d
-          <callValue> 0        </callValue> // I_v
-          <gas>       0        </gas>       // \mu_g
+          <callDepth> 0     </callDepth>
+          <acct>      0     </acct>      // I_a
+          <program>   .Code </program>   // I_b
+          <caller>    0     </caller>    // I_s
+          <callData>  .List </callData>  // I_d
+          <callValue> 0     </callValue> // I_v
+          <gas>       0     </gas>       // \mu_g
         </callState>
 
         <callStack> .List </callStack>

--- a/eei.md
+++ b/eei.md
@@ -249,6 +249,16 @@ The semantics are provided in three forms:
 These methods are used by the other EEI methods as helpers and intermediates to perform larger more complex tasks.
 They are for the most part not intended to be exposed to the execution engine or Ethereum client for direct usage.
 
+### `#done`
+
+This signals that a call to the EEI is complete, and ready to be consumed.
+As such, it has no transition rules, since only an importing module should be able to remove the `#done` from the `<sim>` cell.
+
+```k
+    syntax EEIMethod ::= "#done"
+ // ----------------------------
+```
+
 **TODO**: `{push,pop,drop}Accounts` should be able to take a specific list of accounts to push/pop/drop, making them more efficient.
 
 #### `EEI.pushCallState`

--- a/eei.md
+++ b/eei.md
@@ -53,7 +53,7 @@ For some cells, we have comments following the cell declarations with the name t
       <eei>
         <eeiK> .K </eeiK>
         <statusCode> .StatusCode </statusCode>
-        <returnData> .List       </returnData>
+        <returnData> .Bytes       </returnData>
 ```
 
 The `<callState>` sub-configuration can be saved/restored when needed between calls.
@@ -235,7 +235,7 @@ EEI Methods
 The EEI signals returns results to an outside caller by wrapping it in a `#result`.
 
 ```k
-    syntax ResultType ::= Int | List | Code | Bytes
+    syntax ResultType ::= Int | Code | Bytes
     syntax K ::= "#result" "(" ResultType ")"
  // -----------------------------------------
 ```
@@ -401,7 +401,7 @@ Resets the configuration.
  // --------------------------------------
     rule <eeiK> EEI.clearConfig => . ... </eeiK>
          <statusCode> _ => .StatusCode </statusCode>
-         <returnData> _ => .List       </returnData>
+         <returnData> _ => .Bytes      </returnData>
          <callState>
            <callDepth>  _ => 0        </callDepth>
            <acct>       _ => 0        </acct>      // I_a
@@ -830,7 +830,7 @@ In any case, the status is set to `EVMC_SUCCESS`.
 
 2.  Add `ACCT` to the set `eei.substate.selfDestruct`.
 
-3.  Set `eei.returnData` to `.List` (empty).
+3.  Set `eei.returnData` to `.Bytes` (empty).
 
 4.  Load `BALFROM` from `eei.accounts[ACCT].balance`.
 
@@ -848,7 +848,7 @@ In any case, the status is set to `EVMC_SUCCESS`.
     rule <eeiK> EEI.selfDestruct ACCTTO => . ... </eeiK>
          <statusCode> _ => EVMC_SUCCESS </statusCode>
          <acct> ACCT </acct>
-         <returnData> _ => .List </returnData>
+         <returnData> _ => .Bytes </returnData>
          <selfDestruct> ... (.Set => SetItem(ACCT)) ... </selfDestruct>
          <accounts>
            <account>
@@ -868,7 +868,7 @@ In any case, the status is set to `EVMC_SUCCESS`.
     rule <eeiK> EEI.selfDestruct ACCT => . ... </eeiK>
          <statusCode> _ => EVMC_SUCCESS </statusCode>
          <acct> ACCT </acct>
-         <returnData> _ => .List </returnData>
+         <returnData> _ => .Bytes </returnData>
          <selfDestruct> ... (.Set => SetItem(ACCT)) ... </selfDestruct>
          <accounts>
            <account>
@@ -880,7 +880,7 @@ In any case, the status is set to `EVMC_SUCCESS`.
          </accounts>
 ```
 
-#### `EEI.return : List`
+#### `EEI.return : Bytes`
 
 Set the return data to the given list of `RDATA` as well setting the status code to `EVMC_SUCCESS`.
 
@@ -889,14 +889,14 @@ Set the return data to the given list of `RDATA` as well setting the status code
 2.  Set `eei.statusCode` to `EVMC_SUCCESS`.
 
 ```k
-    syntax EEIMethod ::= "EEI.return" List
- // --------------------------------------
+    syntax EEIMethod ::= "EEI.return" Bytes
+ // ---------------------------------------
     rule <eeiK> EEI.return RDATA => . ... </eeiK>
          <statusCode> _ => EVMC_SUCCESS </statusCode>
          <returnData> _ => RDATA </returnData>
 ```
 
-#### `EEI.revert : List`
+#### `EEI.revert : Bytes`
 
 Set the return data to the given list of `RDATA` as well setting the status code to `EVMC_REVERT`.
 
@@ -905,8 +905,8 @@ Set the return data to the given list of `RDATA` as well setting the status code
 2.  Set `eei.statusCode` to `EVMC_REVERT`.
 
 ```k
-    syntax EEIMethod ::= "EEI.revert" List
- // --------------------------------------
+    syntax EEIMethod ::= "EEI.revert" Bytes
+ // ---------------------------------------
     rule <eeiK> EEI.revert RDATA => . ... </eeiK>
          <statusCode> _ => EVMC_REVERT </statusCode>
          <returnData> _ => RDATA </returnData>
@@ -980,12 +980,13 @@ Helper for setting up the execution engine to run a specific code as if called b
 
 8.  Set `eei.callState.callData` to `ARGS`.
 
-9.  Set `eei.returnData` to the empty `.List`.
+9.  Set `eei.returnData` to the empty `.Bytes`.
 
 ```k
     syntax EEIMethod ::= "EEI.callInit" Int Int Int Int Code Bytes
  // --------------------------------------------------------------
     rule <eeiK> EEI.callInit ACCTFROM ACCTTO APPVALUE GAVAIL CODE ARGS => . ... </eeiK>
+         <returnData>   _ => .Bytes                   </returnData>
          <callState>
            <callDepth>  CALLDEPTH => CALLDEPTH +Int 1 </callDepth>
            <caller>     _         => ACCTFROM         </caller>

--- a/eei.md
+++ b/eei.md
@@ -30,6 +30,7 @@ requires "domains.k"
 
 module EEI
     imports DOMAINS
+    imports BYTES
 ```
 
 Execution State
@@ -60,13 +61,13 @@ When stored, it's stored in the `<callStack>` cell as a list.
 
 ```k
         <callState>
-          <callDepth> 0     </callDepth>
-          <acct>      0     </acct>      // I_a
-          <program>   .Code </program>   // I_b
-          <caller>    0     </caller>    // I_s
-          <callData>  .List </callData>  // I_d
-          <callValue> 0     </callValue> // I_v
-          <gas>       0     </gas>       // \mu_g
+          <callDepth> 0      </callDepth>
+          <acct>      0      </acct>      // I_a
+          <program>   .Code  </program>   // I_b
+          <caller>    0      </caller>    // I_s
+          <callData>  .Bytes </callData>  // I_d
+          <callValue> 0      </callValue> // I_v
+          <gas>       0      </gas>       // \mu_g
         </callState>
 
         <callStack> .List </callStack>
@@ -234,7 +235,7 @@ EEI Methods
 The EEI signals returns results to an outside caller by wrapping it in a `#result`.
 
 ```k
-    syntax ResultType ::= Int | List | Code
+    syntax ResultType ::= Int | List | Code | Bytes
     syntax K ::= "#result" "(" ResultType ")"
  // -----------------------------------------
 ```
@@ -406,7 +407,7 @@ Resets the configuration.
            <acct>       _ => 0        </acct>      // I_a
            <program>    _ => .Code    </program>   // I_b
            <caller>     _ => 0        </caller>    // I_s
-           <callData>   _ => .List    </callData>  // I_d
+           <callData>   _ => .Bytes   </callData>  // I_d
            <callValue>  _ => 0        </callValue> // I_v
            <gas>        _ => 0        </gas>       // \mu_g
          </callState>
@@ -982,8 +983,8 @@ Helper for setting up the execution engine to run a specific code as if called b
 9.  Set `eei.returnData` to the empty `.List`.
 
 ```k
-    syntax EEIMethod ::= "EEI.callInit" Int Int Int Int Code List
- // -------------------------------------------------------------
+    syntax EEIMethod ::= "EEI.callInit" Int Int Int Int Code Bytes
+ // --------------------------------------------------------------
     rule <eeiK> EEI.callInit ACCTFROM ACCTTO APPVALUE GAVAIL CODE ARGS => . ... </eeiK>
          <callState>
            <callDepth>  CALLDEPTH => CALLDEPTH +Int 1 </callDepth>
@@ -1047,8 +1048,8 @@ Call into account `ACCTTO`, with gas allocation `GAVAIL`, apparent value `APPVAL
     iv.   Call `EEI.execute`.
 
 ```k
-    syntax EEIMethod ::= "EEI.call" Int Int Int List
- // ------------------------------------------------
+    syntax EEIMethod ::= "EEI.call" Int Int Int Bytes
+ // -------------------------------------------------
     rule <eeiK> EEI.call ACCTTO GAVAIL APPVALUE ARGS => . ... </eeiK>
          <statusCode> _ => EVMC_CALL_DEPTH_EXCEEDED </statusCode>
          <callDepth> CALLDEPTH </callDepth>
@@ -1081,8 +1082,8 @@ Call into account `ACCTTO`, transfering value `VALUE`, with gas allocation `GAVA
 2.  Call `EEI.onGoodStatus (EEI.call ACCTTO VALUE GAVAIL ARGS)`.
 
 ```k
-    syntax EEIMethod ::= "EEI.transferCall" Int Int Int List
- // --------------------------------------------------------
+    syntax EEIMethod ::= "EEI.transferCall" Int Int Int Bytes
+ // ---------------------------------------------------------
     rule <eeiK> EEI.transferCall ACCTTO VALUE GAVAIL ARGS
           => EEI.transfer VALUE ACCTTO
           ~> EEI.onGoodStatus (EEI.call ACCTTO VALUE GAVAIL ARGS)

--- a/eei.md
+++ b/eei.md
@@ -1016,7 +1016,7 @@ Helper for setting up the execution engine to run a specific code as if called b
  // ----------------------------------
 ```
 
-#### `EEI.call : Int Int Int List`
+#### `EEI.call : Int Int Int Bytes`
 
 **TODO**: Parameterize the `1024` max call depth.
 
@@ -1074,7 +1074,7 @@ Call into account `ACCTTO`, with gas allocation `GAVAIL`, apparent value `APPVAL
       requires CALLDEPTH <Int 1024
 ```
 
-#### `EEI.transferCall : Int Int Int List`
+#### `EEI.transferCall : Int Int Int Bytes`
 
 Call into account `ACCTTO`, transfering value `VALUE`, with gas allocation `GAVAIL`, and arguments `ARGS`.
 

--- a/eei.md
+++ b/eei.md
@@ -370,7 +370,7 @@ If the statuscode is not exception, execute `ETHSIMULATIONGOOD`, otherwise execu
 
 ```k
     syntax EEIMethod ::= "EEI.ifStatus" EEIMethods EEIMethods
- // -------------------------------------------------------------------------
+ // ---------------------------------------------------------
     rule <eeiK> EEI.ifStatus ETHSIMULATIONGOOD ETHSIMULATIONBAD => ETHSIMULATIONGOOD ... </eeiK>
          <statusCode> STATUSCODE </statusCode>
       requires notBool isExceptionalStatusCode(STATUSCODE)
@@ -388,7 +388,7 @@ Executes the given `ETHSIMULATION` if the current status code is not exceptional
 
 ```k
     syntax EEIMethod ::= "EEI.onGoodStatus" EEIMethods
- // ----------------------------------------------------------
+ // --------------------------------------------------
     rule <eeiK> EEI.onGoodStatus ETHSIMULATION => EEI.ifStatus ETHSIMULATION .EEIMethods ... </eeiK>
 ```
 

--- a/eei.md
+++ b/eei.md
@@ -50,7 +50,7 @@ For some cells, we have comments following the cell declarations with the name t
 ```k
     configuration
       <eei>
-        <eeiK> .EEIMethods:K </eeiK>
+        <eeiK> .K </eeiK>
         <statusCode> .StatusCode </statusCode>
         <returnData> .List       </returnData>
 ```

--- a/eei.md
+++ b/eei.md
@@ -62,7 +62,7 @@ When stored, it's stored in the `<callStack>` cell as a list.
         <callState>
           <callDepth> 0        </callDepth>
           <acct>      0        </acct>      // I_a
-          <program>   .Program </program>   // I_b
+          <program>   .Code    </program>   // I_b
           <caller>    0        </caller>    // I_s
           <callData>  .List    </callData>  // I_d
           <callValue> 0        </callValue> // I_v
@@ -91,11 +91,11 @@ Similar to the `<callState>`, the an `<account>` state can be saved or restored 
 ```k
         <accounts>
           <account multiplicity="*" type="Map">
-            <id>      0        </id>
-            <balance> 0        </balance>
-            <code>    .Program </code>
-            <storage> .Map     </storage>
-            <nonce>   0        </nonce>
+            <id>      0     </id>
+            <balance> 0     </balance>
+            <code>    .Code </code>
+            <storage> .Map  </storage>
+            <nonce>   0     </nonce>
           </account>
         </accounts>
 
@@ -141,10 +141,10 @@ Contract code
 
 The contracts can contain code which can be executed by an execution engine.
 However, the EEI is agnostic to execution engines.
-In this specification, we therefore only allow the constant `.Program` to represent contract code, and an embedder making use of the EEI can extend the `Program` production to include other code.
+In this specification, we therefore only allow the constant `.Code` to represent contract code, and an embedder making use of the EEI can extend the `Code` production to include other code.
 
 ```k
-    syntax Program ::= ".Program"
+    syntax Code ::= ".Code"
 ```
 
 Status Codes
@@ -919,9 +919,9 @@ Transfer `VALUE` funds into account `ACCTTO`.
       requires VALUE <=Int BALFROM
 ```
 
-#### `EEI.callInit : Int Int Int Int Program List`
+#### `EEI.callInit : Int Int Int Int Code List`
 
-Helper for setting up the execution engine to run a specific program as if called by `ACCTFROM` into `ACCTTO`, with apparent value transfer `APPVALUE`, gas allocation `GAVAIL`, program `CODE`, and arguments `ARGS`.
+Helper for setting up the execution engine to run a specific code as if called by `ACCTFROM` into `ACCTTO`, with apparent value transfer `APPVALUE`, gas allocation `GAVAIL`, code `CODE`, and arguments `ARGS`.
 
 1.  Load `CALLDEPTH` from `eei.callState.callDepth`.
 
@@ -935,15 +935,15 @@ Helper for setting up the execution engine to run a specific program as if calle
 
 6.  Set `eei.callState.gas` to `GAVAIL`.
 
-7.  Set `eei.callState.program` to `CODE`.
+7.  Set `eei.callState.code` to `CODE`.
 
 8.  Set `eei.callState.callData` to `ARGS`.
 
 9.  Set `eei.returnData` to the empty `.List`.
 
 ```k
-    syntax EEIMethod ::= "EEI.callInit" Int Int Int Int Program List
- // ----------------------------------------------------------------
+    syntax EEIMethod ::= "EEI.callInit" Int Int Int Int Code List
+ // -------------------------------------------------------------
     rule <sim> EEI.callInit ACCTFROM ACCTTO APPVALUE GAVAIL CODE ARGS => . ... </sim>
          <callState>
            <callDepth>  CALLDEPTH => CALLDEPTH +Int 1 </callDepth>

--- a/eei.md
+++ b/eei.md
@@ -399,9 +399,9 @@ Resets the configuration.
     syntax EEIMethod ::= "EEI.clearConfig"
  // --------------------------------------
     rule <eeiK> EEI.clearConfig => . ... </eeiK>
+         <statusCode> _ => .StatusCode </statusCode>
+         <returnData> _ => .List       </returnData>
          <callState>
-           <statusCode> _ => .StatusCode </statusCode>
-           <returnData> _ => .List       </returnData>
            <callDepth>  _ => 0        </callDepth>
            <acct>       _ => 0        </acct>      // I_a
            <program>    _ => .Code    </program>   // I_b

--- a/eei.md
+++ b/eei.md
@@ -975,7 +975,7 @@ Helper for setting up the execution engine to run a specific code as if called b
 
 6.  Set `eei.callState.gas` to `GAVAIL`.
 
-7.  Set `eei.callState.code` to `CODE`.
+7.  Set `eei.callState.program` to `CODE`.
 
 8.  Set `eei.callState.callData` to `ARGS`.
 

--- a/eei.md
+++ b/eei.md
@@ -211,8 +211,7 @@ These additional status codes indicate that execution has ended in some non-exce
 -   `EVMC_REVERT` indicates that the contract called `REVERT`.
 
 ```k
-    syntax EndStatusCode ::= ExceptionalStatusCode
-                           | "EVMC_SUCCESS"
+    syntax EndStatusCode ::= "EVMC_SUCCESS"
                            | "EVMC_REVERT"
 ```
 

--- a/eei.md
+++ b/eei.md
@@ -234,7 +234,7 @@ EEI Methods
 The EEI signals returns results to an outside caller by wrapping it in a `#result`.
 
 ```k
-    syntax ResultType ::= Int | List
+    syntax ResultType ::= Int | List | Code
     syntax K ::= "#result" "(" ResultType ")"
  // -----------------------------------------
 ```
@@ -497,7 +497,7 @@ If there are not `N` blocks yet, return `0`.
 ```k
     syntax EEIMethod ::= "EEI.getBlockHash" Int
  // -------------------------------------------
-    rule <eeiK> EEI.getBlockHash N => #result(BLKHASHES[N]) ... </eeiK>
+    rule <eeiK> EEI.getBlockHash N => #result( {BLKHASHES[N]}:>Int ) ... </eeiK>
          <hashes> BLKHASHES </hashes>
       requires N <Int 256
 

--- a/eei.md
+++ b/eei.md
@@ -388,6 +388,48 @@ Executes the given `ETHSIMULATION` if the current status code is not exceptional
     rule <eeiK> EEI.onGoodStatus ETHSIMULATION => EEI.ifStatus ETHSIMULATION .EEIMethods ... </eeiK>
 ```
 
+#### `EEI.clearConfig`
+
+Resets the configuration.
+
+```k
+    syntax EEIMethod ::= "EEI.clearConfig"
+ // --------------------------------------
+    rule <eeiK> EEI.clearConfig => . ... </eeiK>
+         <callState>
+           <statusCode> _ => .StatusCode </statusCode>
+           <returnData> _ => .List       </returnData>
+           <callDepth>  _ => 0        </callDepth>
+           <acct>       _ => 0        </acct>      // I_a
+           <program>    _ => .Code    </program>   // I_b
+           <caller>     _ => 0        </caller>    // I_s
+           <callData>   _ => .List    </callData>  // I_d
+           <callValue>  _ => 0        </callValue> // I_v
+           <gas>        _ => 0        </gas>       // \mu_g
+         </callState>
+         <callStack> _ => .List </callStack>
+         <substate>
+           <selfDestruct> _ => .Set  </selfDestruct> // A_s
+           <log>          _ => .List </log>          // A_l
+           <refund>       _ => 0     </refund>       // A_r
+         </substate>
+         <accounts>      _ => .Bag  </accounts>
+         <accountsStack> _ => .List </accountsStack>
+         <tx>
+           <gasPrice> _ => 0 </gasPrice> // I_p
+           <origin>   _ => 0 </origin>   // I_o
+         </tx>
+         <block>
+           <hashes>     _ => .List      </hashes>
+           <coinbase>   _ => 0          </coinbase>         // H_c
+        // <logsBloom>  _ => .WordStack </logsBloom>        // H_b
+           <difficulty> _ => 0          </difficulty>       // H_d
+           <number>     _ => 0          </number>           // H_i
+           <gasLimit>   _ => 0          </gasLimit>         // H_l
+           <timestamp>  _ => 0          </timestamp>        // H_s
+         </block>
+```
+
 ### Block and Transaction Information Getters
 
 Many of the methods exported by the EEI simply query for some state of the current block/transaction.

--- a/eei.md
+++ b/eei.md
@@ -37,7 +37,7 @@ Execution State
 
 Below both a K rule and a prose description of each state transition is given.
 The state is specified using a K *configuration*.
-Each XML-like *cell* contains a field which is relevant to Ethereum client execution (eg. below the first cell is the `<sim>` cell).
+Each XML-like *cell* contains a field which is relevant to Ethereum client execution (eg. below the first cell is the `<eeiK>` cell).
 The default/initial values of the cells are provided along with the declaration of the configuration.
 
 In the texual rules below, we'll refer to cells by accesing subcells with the `.` operator.
@@ -50,7 +50,7 @@ For some cells, we have comments following the cell declarations with the name t
 ```k
     configuration
       <eei>
-        <sim> .EEIMethods:K </sim>
+        <eeiK> .EEIMethods:K </eeiK>
         <statusCode> .StatusCode </statusCode>
         <returnData> .List       </returnData>
 ```
@@ -252,7 +252,7 @@ They are for the most part not intended to be exposed to the execution engine or
 ### `#done`
 
 This signals that a call to the EEI is complete, and ready to be consumed.
-As such, it has no transition rules, since only an importing module should be able to remove the `#done` from the `<sim>` cell.
+As such, it has no transition rules, since only an importing module should be able to remove the `#done` from the `<eeiK>` cell.
 
 ```k
     syntax EEIMethod ::= "#done"
@@ -272,7 +272,7 @@ Saves a copy of the current call state in the `<callStack>`.
 ```k
     syntax EEIMethod ::= "EEI.pushCallState"
  // ----------------------------------------
-    rule <sim> EEI.pushCallState => . ... </sim>
+    rule <eeiK> EEI.pushCallState => . ... </eeiK>
          <callState> CALLSTATE </callState>
          <callStack> (.List => ListItem(CALLSTATE)) ... </callStack>
 ```
@@ -290,7 +290,7 @@ Restores the most recently saved `<callState>`.
 ```k
     syntax EEIMethod ::= "EEI.popCallState"
  // ----------------------------------------
-    rule <sim> EEI.popCallState => . ... </sim>
+    rule <eeiK> EEI.popCallState => . ... </eeiK>
          <callState> _ => CALLSTATE </callState>
          <callStack> (ListItem(CALLSTATE) => .List) ... </callStack>
 ```
@@ -304,7 +304,7 @@ Forgets the most recently saved `<callState>` as reverting back to it will no lo
 ```k
     syntax EEIMethod ::= "EEI.dropCallState"
  // ----------------------------------------
-    rule <sim> EEI.dropCallState => . ... </sim>
+    rule <eeiK> EEI.dropCallState => . ... </eeiK>
          <callStack> (ListItem(_) => .List) ... </callStack>
 ```
 
@@ -319,7 +319,7 @@ Saves a copy of the `<accounts>` state in the `<accountStack>` cell.
 ```k
     syntax EEIMethod ::= "EEI.pushAccounts"
  // ---------------------------------------
-    rule <sim> EEI.pushAccounts => . ... </sim>
+    rule <eeiK> EEI.pushAccounts => . ... </eeiK>
          <accounts> ACCTDATA </accounts>
          <accountsStack> (.List => ListItem(ACCTDATA)) ... </accountsStack>
 ```
@@ -337,7 +337,7 @@ Restores the most recently saved `<accounts>` state.
 ```k
     syntax EEIMethod ::= "EEI.popAccounts"
  // --------------------------------------
-    rule <sim> EEI.popAccounts => . ... </sim>
+    rule <eeiK> EEI.popAccounts => . ... </eeiK>
          <accounts> _ => ACCTDATA </accounts>
          <accountsStack> (ListItem(ACCTDATA) => .List) ... </accountsStack>
 ```
@@ -351,7 +351,7 @@ Forgets the most recently saved `<accounts>` state as reverting back to it will 
 ```k
     syntax EEIMethod ::= "EEI.dropAccounts"
  // ---------------------------------------
-    rule <sim> EEI.dropAccounts => . ... </sim>
+    rule <eeiK> EEI.dropAccounts => . ... </eeiK>
          <accountsStack> (ListItem(_) => .List) ... </accountsStack>
 ```
 
@@ -372,11 +372,11 @@ If the statuscode is not exception, execute `ETHSIMULATIONGOOD`, otherwise execu
 ```k
     syntax EEIMethod ::= "EEI.ifStatus" EEIMethods EEIMethods
  // -------------------------------------------------------------------------
-    rule <sim> EEI.ifStatus ETHSIMULATIONGOOD ETHSIMULATIONBAD => ETHSIMULATIONGOOD ... </sim>
+    rule <eeiK> EEI.ifStatus ETHSIMULATIONGOOD ETHSIMULATIONBAD => ETHSIMULATIONGOOD ... </eeiK>
          <statusCode> STATUSCODE </statusCode>
       requires notBool isExceptionalStatusCode(STATUSCODE)
 
-    rule <sim> EEI.ifStatus ETHSIMULATIONGOOD ETHSIMULATIONBAD => ETHSIMULATIONBAD ... </sim>
+    rule <eeiK> EEI.ifStatus ETHSIMULATIONGOOD ETHSIMULATIONBAD => ETHSIMULATIONBAD ... </eeiK>
          <statusCode> STATUSCODE </statusCode>
       requires isExceptionalStatusCode(STATUSCODE)
 ```
@@ -390,7 +390,7 @@ Executes the given `ETHSIMULATION` if the current status code is not exceptional
 ```k
     syntax EEIMethod ::= "EEI.onGoodStatus" EEIMethods
  // ----------------------------------------------------------
-    rule <sim> EEI.onGoodStatus ETHSIMULATION => EEI.ifStatus ETHSIMULATION .EEIMethods ... </sim>
+    rule <eeiK> EEI.onGoodStatus ETHSIMULATION => EEI.ifStatus ETHSIMULATION .EEIMethods ... </eeiK>
 ```
 
 ### Block and Transaction Information Getters
@@ -407,7 +407,7 @@ Get the coinbase of the current block.
 ```k
     syntax EEIMethod ::= "EEI.getBlockCoinbase"
  // -------------------------------------------
-    rule <sim> EEI.getBlockCoinbase => CBASE ... </sim>
+    rule <eeiK> EEI.getBlockCoinbase => CBASE ... </eeiK>
          <coinbase> CBASE </coinbase>
 ```
 
@@ -420,7 +420,7 @@ Get the difficulty of the current block.
 ```k
     syntax EEIMethod ::= "EEI.getBlockDifficulty"
  // ---------------------------------------------
-    rule <sim> EEI.getBlockDifficulty => DIFF ... </sim>
+    rule <eeiK> EEI.getBlockDifficulty => DIFF ... </eeiK>
          <difficulty> DIFF </difficulty>
 ```
 
@@ -433,7 +433,7 @@ Get the gas limit for the current block.
 ```k
     syntax EEIMethod ::= "EEI.getBlockGasLimit"
  // -------------------------------------------
-    rule <sim> EEI.getBlockGasLimit => GLIMIT ... </sim>
+    rule <eeiK> EEI.getBlockGasLimit => GLIMIT ... </eeiK>
          <gasLimit> GLIMIT </gasLimit>
 ```
 
@@ -457,11 +457,11 @@ If there are not `N` blocks yet, return `0`.
 ```k
     syntax EEIMethod ::= "EEI.getBlockHash" Int
  // -------------------------------------------
-    rule <sim> EEI.getBlockHash N => BLKHASHES[N] ... </sim>
+    rule <eeiK> EEI.getBlockHash N => BLKHASHES[N] ... </eeiK>
          <hashes> BLKHASHES </hashes>
       requires N <Int 256
 
-    rule <sim> EEI.getBlockHash N => 0 ... </sim>
+    rule <eeiK> EEI.getBlockHash N => 0 ... </eeiK>
       requires N >=Int 256
 ```
 
@@ -474,7 +474,7 @@ Get the current block number.
 ```k
     syntax EEIMethod ::= "EEI.getBlockNumber"
  // -----------------------------------------
-    rule <sim> EEI.getBlockNumber => BLKNUMBER ... </sim>
+    rule <eeiK> EEI.getBlockNumber => BLKNUMBER ... </eeiK>
          <number> BLKNUMBER </number>
 ```
 
@@ -487,7 +487,7 @@ Get the timestamp of the last block.
 ```k
     syntax EEIMethod ::= "EEI.getBlockTimestamp"
  // --------------------------------------------
-    rule <sim> EEI.getBlockTimestamp => TSTAMP ... </sim>
+    rule <eeiK> EEI.getBlockTimestamp => TSTAMP ... </eeiK>
          <timestamp> TSTAMP </timestamp>
 ```
 
@@ -500,7 +500,7 @@ Get the gas price of the current transation.
 ```k
     syntax EEIMethod ::= "EEI.getTxGasPrice"
  // ----------------------------------------
-    rule <sim> EEI.getTxGasPrice => GPRICE ... </sim>
+    rule <eeiK> EEI.getTxGasPrice => GPRICE ... </eeiK>
          <gasPrice> GPRICE </gasPrice>
 ```
 
@@ -513,7 +513,7 @@ Get the address which sent this transaction.
 ```k
     syntax EEIMethod ::= "EEI.getTxOrigin"
  // --------------------------------------
-    rule <sim> EEI.getTxOrigin => ORG ... </sim>
+    rule <eeiK> EEI.getTxOrigin => ORG ... </eeiK>
          <origin> ORG </origin>
 ```
 
@@ -530,7 +530,7 @@ Return the address of the currently executing account.
 ```k
     syntax EEIMethod ::= "EEI.getAddress"
  // -------------------------------------
-    rule <sim> EEI.getAddress => ADDR ... </sim>
+    rule <eeiK> EEI.getAddress => ADDR ... </eeiK>
          <acct> ADDR </acct>
 ```
 
@@ -543,7 +543,7 @@ Get the account id of the caller into the current execution.
 ```k
     syntax EEIMethod ::= "EEI.getCaller"
  // ------------------------------------
-    rule <sim> EEI.getCaller => CACCT ... </sim>
+    rule <eeiK> EEI.getCaller => CACCT ... </eeiK>
          <caller> CACCT </caller>
 ```
 
@@ -558,7 +558,7 @@ Returns the calldata associated with this call.
 ```k
     syntax EEIMethod ::= "EEI.getCallData"
  // --------------------------------------
-    rule <sim> EEI.getCallData => CDATA ... </sim>
+    rule <eeiK> EEI.getCallData => CDATA ... </eeiK>
          <callData> CDATA </callData>
 ```
 
@@ -571,7 +571,7 @@ Get the value transferred for the current call.
 ```k
     syntax EEIMethod ::= "EEI.getCallValue"
  // ---------------------------------------
-    rule <sim> EEI.getCallValue => CVALUE ... </sim>
+    rule <eeiK> EEI.getCallValue => CVALUE ... </eeiK>
          <callValue> CVALUE </callValue>
 ```
 
@@ -584,7 +584,7 @@ Get the gas left available for this execution.
 ```k
     syntax EEIMethod ::= "EEI.getGasLeft"
  // -------------------------------------
-    rule <sim> EEI.getGasLeft => GAVAIL ... </sim>
+    rule <eeiK> EEI.getGasLeft => GAVAIL ... </eeiK>
          <gas> GAVAIL </gas>
 ```
 
@@ -599,7 +599,7 @@ Get the return data of the last call.
 ```k
     syntax EEIMethod ::= "EEI.getReturnData"
  // ----------------------------------------
-    rule <sim> EEI.getReturnData => RETDATA ... </sim>
+    rule <eeiK> EEI.getReturnData => RETDATA ... </eeiK>
          <returnData> RETDATA </returnData>
 ```
 
@@ -622,11 +622,11 @@ Deduct the specified amount of gas (`GDEDUCT`) from the available gas.
 ```k
     syntax EEIMethod ::= "EEI.useGas" Int
  // -------------------------------------
-    rule <sim> EEI.useGas GDEDUCT => . ... </sim>
+    rule <eeiK> EEI.useGas GDEDUCT => . ... </eeiK>
          <gas> GAVAIL => GAVAIL -Int GDEDUCT </gas>
       requires GAVAIL >Int GDEDUCT
 
-    rule <sim> EEI.useGas GDEDUCT => . ... </sim>
+    rule <eeiK> EEI.useGas GDEDUCT => . ... </eeiK>
          <statusCode> _ => EVMC_OUT_OF_GAS </statusCode>
          <gas> GAVAIL </gas>
       requires GAVAIL <=Int GDEDUCT
@@ -649,7 +649,7 @@ Return the balance of the current account (`ACCT`).
 ```k
     syntax EEIMethod ::= "EEI.getAccountBalance"
  // --------------------------------------------
-    rule <sim> EEI.getAccountBalance => BAL ... </sim>
+    rule <eeiK> EEI.getAccountBalance => BAL ... </eeiK>
          <acct> ACCT </acct>
          <account>
            <id> ACCT </id>
@@ -669,7 +669,7 @@ Return the code of the current account (`ACCT`).
 ```k
     syntax EEIMethod ::= "EEI.getAccountCode"
  // -----------------------------------------
-    rule <sim> EEI.getAccountCode => ACCTCODE ... </sim>
+    rule <eeiK> EEI.getAccountCode => ACCTCODE ... </eeiK>
          <acct> ACCT </acct>
          <accounts>
            <id> ACCT </id>
@@ -687,7 +687,7 @@ Return the code of the given account `ACCT`.
 ```k
     syntax EEIMethod ::= "EEI.getExternalAccountCode" Int
  // -----------------------------------------------------
-    rule <sim> EEI.getExternalAccountCode ACCT => ACCTCODE ... </sim>
+    rule <eeiK> EEI.getExternalAccountCode ACCT => ACCTCODE ... </eeiK>
          <accounts>
            <id> ACCT </id>
            <code> ACCTCODE </code>
@@ -712,7 +712,7 @@ Return the value at the given `INDEX` in the current executing accout's storage.
 ```k
     syntax EEIMethod ::= "EEI.getAccountStorage" Int
  // ------------------------------------------------
-    rule <sim> EEI.getAccountStorage INDEX => VALUE ... </sim>
+    rule <eeiK> EEI.getAccountStorage INDEX => VALUE ... </eeiK>
          <acct> ACCT </acct>
          <account>
            <id> ACCT </id>
@@ -720,7 +720,7 @@ Return the value at the given `INDEX` in the current executing accout's storage.
            ...
          </account>
 
-    rule <sim> EEI.getAccountStorage INDEX => 0 ... </sim>
+    rule <eeiK> EEI.getAccountStorage INDEX => 0 ... </eeiK>
          <acct> ACCT </acct>
          <account>
            <id> ACCT </id>
@@ -741,7 +741,7 @@ At the given `INDEX` in the executing accounts storage, stores the given `VALUE`
 ```k
     syntax EEIMethod ::= "EEI.setAccountStorage" Int Int
  // ----------------------------------------------------
-    rule <sim> EEI.setAccountStorage INDEX VALUE => . ... </sim>
+    rule <eeiK> EEI.setAccountStorage INDEX VALUE => . ... </eeiK>
          <acct> ACCT </acct>
          <account>
            <id> ACCT </id>
@@ -770,7 +770,7 @@ First we define a log-item, which is an account id and two integer lists (in EVM
 ```k
     syntax EEIMethod ::= "EEI.log" List List
  // ----------------------------------------
-    rule <sim> EEI.log BS1 BS2 => . ... </sim>
+    rule <eeiK> EEI.log BS1 BS2 => . ... </eeiK>
          <acct> ACCT </acct>
          <log> ... (.List => ListItem({ ACCT | BS1 | BS2 })) </log>
 ```
@@ -804,7 +804,7 @@ In any case, the status is set to `EVMC_SUCCESS`.
 ```k
     syntax EEIMethod ::= "EEI.selfDestruct" Int
  // -------------------------------------------
-    rule <sim> EEI.selfDestruct ACCTTO => . ... </sim>
+    rule <eeiK> EEI.selfDestruct ACCTTO => . ... </eeiK>
          <statusCode> _ => EVMC_SUCCESS </statusCode>
          <acct> ACCT </acct>
          <returnData> _ => .List </returnData>
@@ -824,7 +824,7 @@ In any case, the status is set to `EVMC_SUCCESS`.
          </accounts>
       requires ACCTTO =/=K ACCT
 
-    rule <sim> EEI.selfDestruct ACCT => . ... </sim>
+    rule <eeiK> EEI.selfDestruct ACCT => . ... </eeiK>
          <statusCode> _ => EVMC_SUCCESS </statusCode>
          <acct> ACCT </acct>
          <returnData> _ => .List </returnData>
@@ -850,7 +850,7 @@ Set the return data to the given list of `RDATA` as well setting the status code
 ```k
     syntax EEIMethod ::= "EEI.return" List
  // --------------------------------------
-    rule <sim> EEI.return RDATA => . ... </sim>
+    rule <eeiK> EEI.return RDATA => . ... </eeiK>
          <statusCode> _ => EVMC_SUCCESS </statusCode>
          <returnData> _ => RDATA </returnData>
 ```
@@ -866,7 +866,7 @@ Set the return data to the given list of `RDATA` as well setting the status code
 ```k
     syntax EEIMethod ::= "EEI.revert" List
  // --------------------------------------
-    rule <sim> EEI.revert RDATA => . ... </sim>
+    rule <eeiK> EEI.revert RDATA => . ... </eeiK>
          <statusCode> _ => EVMC_REVERT </statusCode>
          <returnData> _ => RDATA </returnData>
 ```
@@ -894,7 +894,7 @@ Transfer `VALUE` funds into account `ACCTTO`.
 ```k
     syntax EEIMethod ::= "EEI.transfer" Int Int
  // -------------------------------------------
-    rule <sim> EEI.transfer ACCTTO VALUE => . ... </sim>
+    rule <eeiK> EEI.transfer ACCTTO VALUE => . ... </eeiK>
          <statusCode> _ => EVMC_BALANCE_UNDERFLOW </statusCode>
          <acct> ACCTFROM </acct>
          <account>
@@ -904,7 +904,7 @@ Transfer `VALUE` funds into account `ACCTTO`.
          </account>
       requires VALUE >Int BALFROM
 
-    rule <sim> EEI.transfer ACCTTO VALUE => . ... </sim>
+    rule <eeiK> EEI.transfer ACCTTO VALUE => . ... </eeiK>
          <acct> ACCTFROM </acct>
          <account>
            <id> ACCTFROM </id>
@@ -944,7 +944,7 @@ Helper for setting up the execution engine to run a specific code as if called b
 ```k
     syntax EEIMethod ::= "EEI.callInit" Int Int Int Int Code List
  // -------------------------------------------------------------
-    rule <sim> EEI.callInit ACCTFROM ACCTTO APPVALUE GAVAIL CODE ARGS => . ... </sim>
+    rule <eeiK> EEI.callInit ACCTFROM ACCTTO APPVALUE GAVAIL CODE ARGS => . ... </eeiK>
          <callState>
            <callDepth>  CALLDEPTH => CALLDEPTH +Int 1 </callDepth>
            <caller>     _         => ACCTFROM         </caller>
@@ -1009,19 +1009,19 @@ Call into account `ACCTTO`, with gas allocation `GAVAIL`, apparent value `APPVAL
 ```k
     syntax EEIMethod ::= "EEI.call" Int Int Int List
  // ------------------------------------------------
-    rule <sim> EEI.call ACCTTO GAVAIL APPVALUE ARGS => . ... </sim>
+    rule <eeiK> EEI.call ACCTTO GAVAIL APPVALUE ARGS => . ... </eeiK>
          <statusCode> _ => EVMC_CALL_DEPTH_EXCEEDED </statusCode>
          <callDepth> CALLDEPTH </callDepth>
       requires CALLDEPTH >=Int 1024
 
-    rule <sim> EEI.call ACCTTO GAVAIL APPVALUE ARGS
+    rule <eeiK> EEI.call ACCTTO GAVAIL APPVALUE ARGS
           => EEI.pushCallState ~> EEI.pushAccounts
           ~> EEI.callInit ACCTFROM ACCTTO APPVALUE GAVAIL CODE ARGS
           ~> EEI.execute
           ~> EEI.callFinish
           ~> EEI.execute
          ...
-         </sim>
+         </eeiK>
          <acct> ACCTFROM </acct>
          <callDepth> CALLDEPTH </callDepth>
          <account>
@@ -1043,11 +1043,11 @@ Call into account `ACCTTO`, transfering value `VALUE`, with gas allocation `GAVA
 ```k
     syntax EEIMethod ::= "EEI.transferCall" Int Int Int List
  // --------------------------------------------------------
-    rule <sim> EEI.transferCall ACCTTO VALUE GAVAIL ARGS
+    rule <eeiK> EEI.transferCall ACCTTO VALUE GAVAIL ARGS
           => EEI.transfer VALUE ACCTTO
           ~> EEI.onGoodStatus (EEI.call ACCTTO VALUE GAVAIL ARGS)
          ...
-         </sim>
+         </eeiK>
 ```
 
 -   `EEI.call` **TODO**

--- a/eei.md
+++ b/eei.md
@@ -4,7 +4,7 @@ EEI specification
 Introduction
 ------------
 
-This document aims to specify an ewasm VM in a way useful to contract writers and VM implementers.
+This document aims to specify an Ethereum VM in a way useful to contract writers and VM implementers (mostly for Ewasm).
 To this end, multiple things are specified:
 
 -   The extra state that a VM needs to have around to successfully respond to calls into the EEI.

--- a/eei.md
+++ b/eei.md
@@ -230,6 +230,12 @@ The following codes indicate other non-execution errors with the execution engin
 EEI Methods
 -----------
 
+The EEI signals returns results to an outside caller by wrapping it in a `#result`.
+
+```k
+    syntax K ::= "#result" "(" Int ")"
+```
+
 The EEI exports several methods which can be invoked by the VM to interact with the client.
 Here the syntax and semantics of these methods is defined.
 
@@ -247,16 +253,6 @@ The semantics are provided in three forms:
 
 These methods are used by the other EEI methods as helpers and intermediates to perform larger more complex tasks.
 They are for the most part not intended to be exposed to the execution engine or Ethereum client for direct usage.
-
-### `#done`
-
-This signals that a call to the EEI is complete, and ready to be consumed.
-As such, it has no transition rules, since only an importing module should be able to remove the `#done` from the `<eeiK>` cell.
-
-```k
-    syntax EEIMethod ::= "#done"
- // ----------------------------
-```
 
 **TODO**: `{push,pop,drop}Accounts` should be able to take a specific list of accounts to push/pop/drop, making them more efficient.
 
@@ -542,7 +538,7 @@ Get the account id of the caller into the current execution.
 ```k
     syntax EEIMethod ::= "EEI.getCaller"
  // ------------------------------------
-    rule <eeiK> EEI.getCaller => CACCT ... </eeiK>
+    rule <eeiK> EEI.getCaller => #result(CACCT) ... </eeiK>
          <caller> CACCT </caller>
 ```
 

--- a/eei.md
+++ b/eei.md
@@ -749,7 +749,7 @@ Return the value at the given `INDEX` in the current executing accout's storage.
 ```k
     syntax EEIMethod ::= "EEI.getAccountStorage" Int
  // ------------------------------------------------
-    rule <eeiK> EEI.getAccountStorage INDEX => VALUE ... </eeiK>
+    rule <eeiK> EEI.getAccountStorage INDEX => #result(VALUE) ... </eeiK>
          <acct> ACCT </acct>
          <account>
            <id> ACCT </id>
@@ -757,7 +757,7 @@ Return the value at the given `INDEX` in the current executing accout's storage.
            ...
          </account>
 
-    rule <eeiK> EEI.getAccountStorage INDEX => 0 ... </eeiK>
+    rule <eeiK> EEI.getAccountStorage INDEX => #result(0) ... </eeiK>
          <acct> ACCT </acct>
          <account>
            <id> ACCT </id>

--- a/eei.md
+++ b/eei.md
@@ -211,7 +211,8 @@ These additional status codes indicate that execution has ended in some non-exce
 -   `EVMC_REVERT` indicates that the contract called `REVERT`.
 
 ```k
-    syntax EndStatusCode ::= "EVMC_SUCCESS"
+    syntax EndStatusCode ::= ExceptionalStatusCode
+                           | "EVMC_SUCCESS"
                            | "EVMC_REVERT"
 ```
 


### PR DESCRIPTION
Most off the diff come from two renamings:

1. `<k>` =>  `<eeiK>` to avoid namespace clashes.
2. `Program` => `Code`, since AFAICT that's the usual term for what a contract contains: code.
3. `EthereumSimulation` and `EthereumCommand` => `EEIMethod` and `EEIMethods`. The naming seems to suggest that the main simulation would run in this configuration, but I found it easier to have the main simulation run in the `<k>` cell of Wasm, and have this specification be very specialized to reading and modifying the Ethereum state, making very clear cut calls into this spec.

Other than that, I added the `#result` production. We could also simply check for `Int` at the top of the `<eeiK>` cell, but that seems less explicit and more error-prone. I'm not hellbent on this change, but I do think it offers nice readability.

I also added `EEI.clearConfig` as a helper, which is mainly used for testing. In the longer run, we would have an `EEI-TEST` module for this (as well as for more unit testing), but not sure it's (yet) worth adding, at least until we have some idea of how we want to structure the repo.